### PR TITLE
removed 'cayman theme'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -58,5 +58,3 @@ footer_content: <a href="https://github.com/CU-Boulder-CRDDS/data_bootcamp" targ
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
-
-theme: jekyll-theme-cayman


### PR DESCRIPTION
this line:
`theme: jekyll-theme-cayman`
 in the _config.yml file was preventing me from running it locally. Maybe it will give others a headache if they attempt to run locally? But, GitHub pages seems to not care. Anyway, I removed it on my fork and it did not mess anything up.

Cayman is one of the standard pages themes, so not sure how that got in there. 

Phil